### PR TITLE
Removing redundant prerequisites

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects_MoreBatteries.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects_MoreBatteries.xml
@@ -8,8 +8,6 @@
 	<baseCost>8000</baseCost>
     <techLevel>Archotech</techLevel>
     <prerequisites>
-    	<li>MicroelectronicsBasics</li>
-      <li>Electricity</li>
       <li>AdvancedBattery</li>
     </prerequisites>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
@@ -25,9 +23,6 @@
 	<baseCost>8000</baseCost>
     <techLevel>Archotech</techLevel>
     <prerequisites>
-    	<li>MicroelectronicsBasics</li>
-      <li>Electricity</li>
-      <li>AdvancedBattery</li>
       <li>ArchotechPowerStorage</li>
     </prerequisites>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
@@ -43,8 +38,6 @@
 	<baseCost>2000</baseCost>
     <techLevel>Spacer</techLevel>
     <prerequisites>
-    	<li>MicroelectronicsBasics</li>
-      <li>Electricity</li>
       <li>MidtierBattery</li>
     </prerequisites>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
@@ -60,9 +53,6 @@
 	<baseCost>1500</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
-    	<li>MicroelectronicsBasics</li>
-      <li>Electricity</li>
-      <li>Batteries</li>
       <li>LowtierBattery</li>
     </prerequisites>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>
@@ -78,8 +68,7 @@
 	<baseCost>1000</baseCost>
     <techLevel>Industrial</techLevel>
     <prerequisites>
-    	<li>MicroelectronicsBasics</li>
-      <li>Electricity</li>
+      <li>MicroelectronicsBasics</li>
       <li>Batteries</li>
     </prerequisites>
     <requiredResearchBuilding>HiTechResearchBench</requiredResearchBuilding>


### PR DESCRIPTION
### Additions

None

### Changes

Removed redundant prerequisites for research tree.

### Reason

Removing Console Spam (Warning) when used together with research tree mods.

### Tests

- [x] Game runs without errors
- [x] Started a new test save

Tested research tree (Requirements exist)

### Notes

None